### PR TITLE
add type is String in option

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ module.exports = class CfParametersPlugin {
                 options: {
                     [OPTION_PARAMETER_OVERRIDES]: {
                         usage: 'Update the cloudformation parameters\' values',
-                        required: false
+                        required: false,
+                        type: String
                     }
                 }
             }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = class CfParametersPlugin {
                     [OPTION_PARAMETER_OVERRIDES]: {
                         usage: 'Update the cloudformation parameters\' values',
                         required: false,
-                        type: String
+                        type: 'string'
                     }
                 }
             }


### PR DESCRIPTION
Hello Phuong,
Thank you about this plugin. It's very helpful to me.

When I use this plugin then after Serverless deployment is complete, my command is displayed warning me as shown below : 
![image](https://user-images.githubusercontent.com/45137828/126301337-9d183c57-7c6a-4db5-9a68-35d4bd2cf49a.png)

After fix then this warning don't shown. I think it should be fix
Thank you for taking the time to review my pull request !!!