### PR TITLE
Update hook command and type of option of command

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ module.exports = class CfParametersPlugin {
         this.providerRequest = this.provider.request.bind(this.provider)
 
         this.hooks = {
+            // this command for Serverless Framework from version 2.* and earlier
+            'before:deploy:deploy': this.interceptProviderRequest.bind(this),
+            // this command for Serverless Framework from version 3.* onwards
             'before:aws:deploy:deploy:updateStack': this.interceptProviderRequest.bind(this),
             'aws:deploy:deploy:checkForChanges': this.preventSkippingDeployment.bind(this)
         }
@@ -31,7 +34,7 @@ module.exports = class CfParametersPlugin {
             let [service, method, params] = args
             let compiledParametersTemplate = this.serverless.service.provider.compiledCloudFormationTemplate.Parameters || {}
 
-            if (service === 'CloudFormation' && method === 'createChangeSet') {
+            if (service === 'CloudFormation' && (method === 'updateStack' || method === 'createChangeSet')) {
                 // Get list of parameters in currently deployed template
                 let response = await this.providerRequest('CloudFormation', 'getTemplate', {StackName: params.StackName})
                 let currentParameters = JSON.parse(response.TemplateBody).Parameters || {}

--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ module.exports = class CfParametersPlugin {
                 options: {
                     [OPTION_PARAMETER_OVERRIDES]: {
                         usage: 'Update the cloudformation parameters\' values',
-                        required: false
+                        required: false,
+                        // support multiple option of command
+                        type: 'string[]'
                     }
                 }
             }
@@ -19,7 +21,7 @@ module.exports = class CfParametersPlugin {
         this.providerRequest = this.provider.request.bind(this.provider)
 
         this.hooks = {
-            'before:deploy:deploy': this.interceptProviderRequest.bind(this),
+            'before:aws:deploy:deploy:updateStack': this.interceptProviderRequest.bind(this),
             'aws:deploy:deploy:checkForChanges': this.preventSkippingDeployment.bind(this)
         }
     }
@@ -29,7 +31,7 @@ module.exports = class CfParametersPlugin {
             let [service, method, params] = args
             let compiledParametersTemplate = this.serverless.service.provider.compiledCloudFormationTemplate.Parameters || {}
 
-            if (service === 'CloudFormation' && method === 'updateStack') {
+            if (service === 'CloudFormation' && method === 'createChangeSet') {
                 // Get list of parameters in currently deployed template
                 let response = await this.providerRequest('CloudFormation', 'getTemplate', {StackName: params.StackName})
                 let currentParameters = JSON.parse(response.TemplateBody).Parameters || {}

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = class CfParametersPlugin {
                         usage: 'Update the cloudformation parameters\' values',
                         required: false,
                         // support multiple option of command
-                        type: 'string[]'
+                        type: 'multiple'
                     }
                 }
             }


### PR DESCRIPTION
1. Serverless framework version 3.* : 
When I run multiple option of command : sls deploy --parameter-overrides UseParam1=true --parameter-overrides UseParam2=false 
then Serverless framework throw 「Unexpected multiple "--parameter-overrides"」message
=> Issue: we use _type is string_ of option of command
=> Solution: set _type is string[]_
2. Serverless framework version 3.* : 
When I run command : sls deploy --parameter-overrides UseParam=true 
then it don't apply true value of UseParam. It only use default value

Issue:
- in 「before:deploy:deploy」command: not exist _method is updateStack_ with _service is CloudFormation_

Solution: 
+ use 「before:aws:deploy:deploy:updateStack」command to instead of
+ use _method is createChangeSet_ and _service is CloudFormation_